### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
    recycleview方式实现连接为： https://github.com/dalong982242260/GalleryRecycleView
   欢迎star,如果有问题可以给我留言。
   
-##效果图
+## 效果图
 
-###水平
+### 水平
 ![image](https://github.com/dalong982242260/SlidingBallViewPager/blob/master/img/hor.gif)
 
-###竖直
+### 竖直
 ![image](https://github.com/dalong982242260/SlidingBallViewPager/blob/master/img/ver.gif)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
